### PR TITLE
Fix setup.sh to work on Linux for Claude Code users

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Crux exposes its capabilities via the Model Context Protocol, making them availa
 
 ### Prerequisites
 
-- macOS (Apple Silicon) or Linux
+- macOS or Linux (Ubuntu 24.04+, Debian, etc.)
 - Python 3.10+
 - Git
 
@@ -108,7 +108,7 @@ Crux exposes its capabilities via the Model Context Protocol, making them availa
 ```bash
 git clone https://github.com/trinsiklabs/crux.git ~/.crux
 ~/.crux/setup.sh        # Select "Claude Code" — installs deps + CLI (~10 seconds)
-source ~/.zshrc
+source ~/.bashrc          # or ~/.zshrc on macOS
 
 cd your-project
 crux adopt               # Sets up .crux/, MCP server (37 tools), and hooks

--- a/setup.sh
+++ b/setup.sh
@@ -220,6 +220,13 @@ detect_hardware() {
 
     header "STEP 1: Hardware Detection"
 
+    if [[ "$OSTYPE" != "darwin"* ]]; then
+        error "Hardware detection requires macOS (Apple Silicon)."
+        error "OpenCode local LLM setup is currently macOS-only."
+        error "For Linux, use: ./setup.sh and select Claude Code."
+        exit 1
+    fi
+
     info "Detecting system hardware..."
 
     # Total RAM in bytes
@@ -1561,9 +1568,14 @@ summary_claude_code() {
     echo -e "${CYAN}→${NC} Crux is ready for Claude Code!"
     echo ""
 
+    local shell_rc="~/.bashrc"
+    if [[ "${SHELL:-}" == *"zsh"* ]]; then
+        shell_rc="~/.zshrc"
+    fi
+
     echo -e "${BOLD}Quick Start:${NC}"
     echo "  1. Reload your shell:"
-    echo "       source ~/.zshrc"
+    echo "       source $shell_rc"
     echo ""
     echo "  2. Adopt Crux into any project:"
     echo "       cd your-project"
@@ -1668,21 +1680,9 @@ main() {
         echo "╔════════════════════════════════════════════════════════════╗"
         echo "║                                                          ║"
         echo "║            Crux Setup - Self-Improving AI OS             ║"
-        echo "║                macOS (Apple Silicon)                      ║"
         echo "║                                                          ║"
         echo "╚════════════════════════════════════════════════════════════╝"
         echo -e "${NC}\n"
-
-        # Check prerequisites
-        if [[ "$OSTYPE" != "darwin"* ]]; then
-            error "This script is for macOS only"
-            exit 1
-        fi
-
-        if ! sysctl hw.memsize &> /dev/null; then
-            error "Could not detect system hardware"
-            exit 1
-        fi
     fi
 
     # Select tool (or read from state in update mode)


### PR DESCRIPTION
## Summary

- Remove macOS-only gate from setup.sh — it blocked Linux users even though the Claude Code path (pip install + CLI symlink) is platform-independent
- Move the macOS check into `detect_hardware()` so it only gates the OpenCode/Ollama local LLM path
- Fix shell profile detection (bash vs zsh) in setup summary
- Update README prerequisites to include Linux

## Test plan

- [x] `bash -n setup.sh` passes
- [x] Claude Code path has no macOS-specific commands
- [x] OpenCode path still gates on macOS at hardware detection step

🤖 Generated with [Claude Code](https://claude.com/claude-code)