### PR TITLE
Use venv for Python deps, fix Linux support (Ubuntu 24.04)

### DIFF
--- a/scripts/lib/crux_adopt.py
+++ b/scripts/lib/crux_adopt.py
@@ -220,13 +220,14 @@ def adopt_project(
     os.makedirs(claude_dir, exist_ok=True)
 
     # 8a. MCP server config
-    import sys
-    crux_repo = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from scripts.lib.crux_paths import get_crux_python, get_crux_repo
+    python_path = get_crux_python()
+    crux_repo = get_crux_repo()
     mcp_json_path = os.path.join(claude_dir, "mcp.json")
     mcp_config = {
         "mcpServers": {
             "crux": {
-                "command": sys.executable,
+                "command": python_path,
                 "args": ["-m", "scripts.lib.crux_mcp_server"],
                 "env": {
                     "CRUX_PROJECT": project_dir,

--- a/scripts/lib/crux_hooks.py
+++ b/scripts/lib/crux_hooks.py
@@ -461,10 +461,9 @@ def run_hook(
 
 def build_hook_settings(project_dir: str, home: str) -> dict:
     """Build the hooks configuration for .claude/settings.local.json."""
-    # Use absolute python path and PYTHONPATH for reliability across projects
-    import sys
-    python = sys.executable
-    crux_repo = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from scripts.lib.crux_paths import get_crux_python, get_crux_repo
+    python = get_crux_python()
+    crux_repo = get_crux_repo()
     runner = f"PYTHONPATH={crux_repo} {python} -m scripts.lib.crux_hook_runner"
 
     return {

--- a/scripts/lib/crux_paths.py
+++ b/scripts/lib/crux_paths.py
@@ -169,6 +169,26 @@ class ProjectPaths:
         return os.path.join(self.root, "models", "registry.json")
 
 
+def get_crux_repo() -> str:
+    """Return the absolute path to the Crux repo root."""
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def get_crux_python() -> str:
+    """Return the Python executable for running Crux scripts.
+
+    Prefers the venv Python at <repo>/.venv/bin/python if it exists (needed on
+    Linux where the system Python is externally managed). Falls back to the
+    current interpreter.
+    """
+    import sys
+    repo = get_crux_repo()
+    venv_python = os.path.join(repo, ".venv", "bin", "python")
+    if os.path.isfile(venv_python):
+        return venv_python
+    return sys.executable
+
+
 def get_user_paths(home: str | None = None) -> UserPaths:
     """Get user-level Crux paths (~/.crux/)."""
     if home is None:

--- a/scripts/lib/crux_sync.py
+++ b/scripts/lib/crux_sync.py
@@ -141,7 +141,8 @@ def _safe_write(path: str, content: str) -> None:
 
 def _crux_repo_root() -> str:
     """Resolve the Crux repo root (where scripts/, templates/ live)."""
-    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from scripts.lib.crux_paths import get_crux_repo
+    return get_crux_repo()
 
 
 CRUX_AGENTS_START = "<!-- CRUX:START -->"
@@ -229,7 +230,7 @@ def sync_opencode(project_dir: str, home: str) -> SyncResult:
 
 def _write_opencode_mcp_config(config_dir: str, project_dir: str, home: str) -> None:
     """Write or merge Crux MCP server config into opencode.json."""
-    import sys
+    from scripts.lib.crux_paths import get_crux_python
 
     config_file = os.path.join(config_dir, "opencode.json")
 
@@ -243,7 +244,7 @@ def _write_opencode_mcp_config(config_dir: str, project_dir: str, home: str) -> 
             existing = {}
 
     # Build the Crux MCP entry in OpenCode format
-    python_path = sys.executable
+    python_path = get_crux_python()
     crux_repo = _crux_repo_root()
     crux_mcp: dict = {
         "type": "local",
@@ -360,7 +361,7 @@ def _build_context_md(project_dir: str) -> str:
 
 def _write_mcp_config(config_path: str, project_dir: str, home: str) -> None:
     """Write or merge Crux MCP server entry into a JSON config file."""
-    import sys
+    from scripts.lib.crux_paths import get_crux_python
 
     existing: dict = {}
     if os.path.exists(config_path):
@@ -370,7 +371,7 @@ def _write_mcp_config(config_path: str, project_dir: str, home: str) -> None:
         except (json.JSONDecodeError, OSError):
             existing = {}
 
-    python_path = sys.executable
+    python_path = get_crux_python()
     crux_repo = _crux_repo_root()
     crux_mcp: dict = {
         "command": python_path,

--- a/setup.sh
+++ b/setup.sh
@@ -184,7 +184,12 @@ install_python_deps() {
     header "Installing Python Dependencies"
 
     if ! command -v python3 &>/dev/null; then
-        error "Python 3 not found. Install via: brew install python3"
+        error "Python 3 not found."
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            error "Install via: brew install python3"
+        else
+            error "Install via: sudo apt install python3 python3-venv"
+        fi
         return 1
     fi
 
@@ -192,20 +197,39 @@ install_python_deps() {
     py_version=$(python3 --version 2>&1)
     success "Python: $py_version"
 
-    # Check if mcp is already installed
-    if python3 -c "import mcp" 2>/dev/null; then
+    local venv_dir="$CRUX_DIR/.venv"
+
+    # Create venv if it doesn't exist
+    if [ ! -d "$venv_dir" ]; then
+        info "Creating Python virtual environment..."
+        if ! python3 -m venv "$venv_dir" 2>/dev/null; then
+            # On Ubuntu/Debian, python3-venv may not be installed
+            error "Failed to create venv. On Ubuntu/Debian, run:"
+            error "  sudo apt install python3-venv"
+            error "Then re-run setup.sh"
+            return 1
+        fi
+        success "Created venv at $venv_dir"
+    else
+        success "Venv already exists at $venv_dir"
+    fi
+
+    # Install deps into venv
+    local venv_python="$venv_dir/bin/python"
+    if "$venv_python" -c "import mcp" 2>/dev/null; then
         success "MCP package already installed"
     else
-        info "Installing MCP package (required for Crux MCP server)..."
-        if python3 -m pip install -r "$CRUX_DIR/requirements.txt" 2>/dev/null; then
-            success "MCP package installed"
-        elif pip3 install -r "$CRUX_DIR/requirements.txt" 2>/dev/null; then
+        info "Installing MCP package into venv..."
+        if "$venv_python" -m pip install -r "$CRUX_DIR/requirements.txt" 2>&1 | tail -1; then
             success "MCP package installed"
         else
-            error "Failed to install MCP package. Run manually: pip install mcp"
+            error "Failed to install MCP package"
             return 1
         fi
     fi
+
+    # Save venv python path for other components to use
+    state_save "venv_python" "$venv_python"
 }
 
 ###############################################################################

--- a/tests/test_crux_adopt.py
+++ b/tests/test_crux_adopt.py
@@ -257,7 +257,7 @@ class TestAdoptMCPSetup:
         assert "crux" in data["mcpServers"]
 
     def test_mcp_json_has_absolute_python_path(self, project_with_git):
-        import sys
+        from scripts.lib.crux_paths import get_crux_python
         adopt_project(
             project_dir=project_with_git["project"],
             home=project_with_git["home"],
@@ -265,7 +265,8 @@ class TestAdoptMCPSetup:
         mcp_json = Path(project_with_git["project"]) / ".claude" / "mcp.json"
         data = json.loads(mcp_json.read_text())
         server = data["mcpServers"]["crux"]
-        assert server["command"] == sys.executable
+        assert server["command"] == get_crux_python()
+        assert os.path.isabs(server["command"])
         assert "-m" in server["args"]
         assert "scripts.lib.crux_mcp_server" in server["args"]
 


### PR DESCRIPTION
## Summary

- Setup now creates `.venv/` inside the crux repo and installs `mcp` there
- All MCP configs and hook commands use `get_crux_python()` which prefers the venv Python — fixes "externally managed environment" errors on Ubuntu/Debian
- Tested with 1214 pytest + 46 bats tests passing

## Test plan

- [x] All tests pass
- [x] `bash -n setup.sh` passes
- [x] `get_crux_python()` returns venv path when `.venv/` exists, falls back to `sys.executable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)