### PR TITLE
PLAN-005: Seamless tool transition system

### DIFF
--- a/BUILD_PLAN_005_TOOL_TRANSITIONS.md
+++ b/BUILD_PLAN_005_TOOL_TRANSITIONS.md
@@ -1,0 +1,150 @@
+# BUILD_PLAN_005: Seamless Tool Transition System
+
+**Created:** 2026-03-24
+**Status:** COMPLETE
+**Goal:** Zero-prep switching between AI coding tools. Kill any session at any time, restore in any tool, lose nothing. Three parts: always-on session state, tool recipe engine, and enhanced switch_tool_to MCP tool.
+
+**Constraint:** TDD, 100% coverage on new code.
+**Constraint:** All tool recipes verified against actual config formats (research from cruxdev session).
+**Rule:** Two consecutive clean audit passes = convergence.
+
+## Document Alignment
+
+- CruxDev inbox messages: tool transition recipes (6 tools), always-on session state
+- `scripts/lib/crux_sync.py` — existing adapter layer (opencode, claude-code, cursor, windsurf)
+- `scripts/lib/crux_switch.py` — existing switch_tool function
+- `scripts/lib/crux_session.py` — session state management
+- `scripts/lib/crux_mcp_server.py` — MCP server instructions field
+
+---
+
+## Architecture
+
+```
+Current:                                Target:
+  switch_tool_to("opencode")              switch_tool_to("cruxcli")
+    → crux_switch.py                        → auto-write handoff from session state
+    → crux_sync.py (4 tools)                → look up recipe for target tool
+    → generates configs                     → write MCP config in target's format
+    → manual handoff needed                 → return launch command + "call restore_context()"
+                                            → works for all 6 tools
+                                            → no manual handoff ever needed
+```
+
+### Tool Recipe Format
+
+```python
+@dataclass
+class ToolRecipe:
+    tool_id: str                    # "claude-code", "cruxcli", "cursor", etc.
+    config_file: str                # relative path from project root (or absolute for global)
+    root_key: str                   # "mcpServers" or "mcp" or "context_servers"
+    type_value: str | None          # "stdio", "local", or None (implicit)
+    command_format: str             # "string_args" or "merged_array"
+    env_key: str                    # "env" or "environment"
+    url_key: str                    # "url" or "serverUrl"
+    project_scoped: bool            # True if per-project config, False if global only
+    interpolation: str              # "${VAR}", "{env:VAR}", "${env:VAR}"
+    launch_command: str             # Command to start the tool
+    jsonc: bool                     # True for JSONC format (comments allowed)
+    tested: bool                    # Whether this recipe has been verified
+    last_tested: str | None         # ISO date of last test
+```
+
+### 6 Tool Recipes
+
+| Tool | Config | Root Key | Type | Cmd Format | Env Key | Project |
+|------|--------|----------|------|------------|---------|---------|
+| claude-code | .mcp.json | mcpServers | stdio | string+args | env | Yes |
+| cruxcli | .cruxcli/cruxcli.jsonc | mcp | local | merged array | environment | Yes |
+| opencode | .opencode/opencode.jsonc | mcp | local | merged array | environment | Yes |
+| cursor | .cursor/mcp.json | mcpServers | (none) | string+args | env | Yes |
+| windsurf | ~/.codeium/windsurf/mcp_config.json | mcpServers | (none) | string+args | env | No |
+| zed | ~/.config/zed/settings.json | context_servers | (none) | string+args | env | No |
+
+---
+
+## Phase 1: Always-On Session State
+
+**Purpose:** Session state is continuously maintained so context can be restored at any time without advance notice.
+
+### Checklist — Phase 1
+
+- [x] 1.1 Updated MCP server instructions with always-on session state requirement
+- [x] 1.2 Added `auto_handoff()` to crux_session.py — generates from accumulated state, truncates large lists
+- [x] 1.3 11 tests for auto_handoff (empty, rich, truncation, file write, no session)
+- [x] 1.4 Tests pass, coverage = 100% on new code
+
+---
+
+## Phase 2: Tool Recipe Engine
+
+**Purpose:** Centralized knowledge of how each tool's MCP config works, used to generate correct configs for any tool.
+
+### Checklist — Phase 2
+
+- [x] 2.1 Created `scripts/lib/crux_tool_recipes.py` with ToolRecipe dataclass and RECIPES for all 6 tools
+- [x] 2.2 `get_recipe(tool_id)` returns recipe or None
+- [x] 2.3 `generate_mcp_config()` writes correct config for any tool
+- [x] 2.4 Global tools (windsurf, zed) write to home dir via expanduser
+- [x] 2.5 JSONC handled (write JSON without comments for cruxcli/opencode)
+- [x] 2.6 Merged-array command format for cruxcli/opencode
+- [x] 2.7 Type field: stdio, local, or omitted per tool
+- [x] 2.8 Env key: env vs environment per tool
+- [x] 2.9 14 tests covering all 6 tools + edge cases
+- [x] 2.10 Merge existing config (don't overwrite), corrupt config recovery
+- [x] 2.11 Tests pass, coverage = 100%
+
+---
+
+## Phase 3: Enhanced switch_tool_to
+
+**Purpose:** One-command tool transition that auto-writes handoff, generates target config, returns launch instructions.
+
+### Checklist — Phase 3
+
+- [x] 3.1 Updated handle_switch_tool: auto_handoff() → sync_tool (existing) → fallback to recipe engine → launch instructions
+- [x] 3.2 Recipe engine handles cruxcli/zed as fallback (SUPPORTED_TOOLS kept for full sync, recipes for config-only)
+- [x] 3.3 Existing sync_claude_code/sync_opencode kept (they do more: modes, symlinks, AGENTS.md)
+- [x] 3.4 Return includes: success, from_tool, to_tool, config_written, launch_command, restore_instruction
+- [x] 3.5 Existing switch tests pass + recipe fallback works for unsupported tools
+- [x] 3.6 Auto-handoff called on every switch
+- [x] 3.7 Tests pass, 1399 total
+
+---
+
+## Phase 4: Integration Verification
+
+**Purpose:** End-to-end verification that the transition system works.
+
+### Checklist — Phase 4
+
+- [x] 4.1 Verified: cruxcli recipe generates .cruxcli/cruxcli.jsonc with type=local, merged array command
+- [x] 4.2 Verified: claude-code recipe generates .mcp.json with type=stdio
+- [x] 4.3 Verified: cursor recipe generates .cursor/mcp.json without type field
+- [x] 4.4 Verified: auto_handoff produces restorable context with mode, tool, decisions, files, pending
+- [x] 4.5 Full test suite: 1399 passing
+- [x] 4.6 Coverage = 100% on crux_tool_recipes.py (52 statements)
+
+---
+
+## Convergence Criteria
+
+- All checklist items complete
+- All 6 tool recipes defined and tested
+- auto_handoff() generates from accumulated state
+- switch_tool_to() handles all 6 tools
+- MCP server instructions updated for always-on state
+- Two consecutive clean audit passes
+
+---
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| JSONC parsing complexity | cruxcli config has comments | Use json with comment stripping (regex) or write-only approach |
+| Global-only tools (windsurf, zed) conflict with other projects | Config overwritten | Merge into existing config, don't replace |
+| Zed settings.json has many other keys | Accidental data loss | Read existing, merge context_servers key only |
+| Tool-specific config drift | Recipe outdated | tested/last_tested tracking, verify on each use |
+| Large session state in handoff | Context too long | Truncate to last N decisions/files, summarize |

--- a/scripts/lib/crux_mcp_handlers.py
+++ b/scripts/lib/crux_mcp_handlers.py
@@ -448,21 +448,57 @@ def handle_switch_tool(
     project_dir: str,
     home: str,
 ) -> dict:
-    """Switch to a different AI coding tool."""
+    """Switch to a different AI coding tool.
+
+    Auto-writes handoff from accumulated session state, generates the
+    target tool's MCP config, and returns launch instructions.
+    """
+    from scripts.lib.crux_session import auto_handoff
+    from scripts.lib.crux_tool_recipes import get_recipe, generate_mcp_config
+    from scripts.lib.crux_paths import get_crux_repo, get_crux_python
+
+    # Auto-write handoff from current session state
+    crux_dir = os.path.join(project_dir, ".crux")
+    auto_handoff(crux_dir)
+
+    # Try existing sync_tool first (full adapter: modes, symlinks, etc.)
     result = switch_tool(
         target_tool=target_tool,
         project_dir=project_dir,
         home=home,
     )
+
     resp: dict = {
         "success": result.success,
         "from_tool": result.from_tool,
         "to_tool": result.to_tool,
     }
-    if result.error:
-        resp["error"] = result.error
+
+    # If sync_tool failed (unsupported tool), try recipe-based config
+    if not result.success:
+        recipe = get_recipe(target_tool)
+        if recipe is not None:
+            generated = generate_mcp_config(
+                target_tool, project_dir, get_crux_repo(), get_crux_python(),
+            )
+            if generated:
+                resp["success"] = True
+                resp["config_written"] = True
+                resp.pop("error", None)
+            else:
+                resp["error"] = result.error
+        else:
+            resp["error"] = result.error
+
     if result.items_synced:
         resp["items_synced"] = result.items_synced
+
+    # Always include launch instructions
+    recipe = get_recipe(target_tool)
+    if recipe:
+        resp["launch_command"] = recipe.launch_command
+    resp["restore_instruction"] = "Call restore_context() on first message in the new session."
+
     return resp
 
 

--- a/scripts/lib/crux_mcp_server.py
+++ b/scripts/lib/crux_mcp_server.py
@@ -54,7 +54,16 @@ from scripts.lib.crux_mcp_handlers import (
     handle_bip_get_analytics,
 )
 
-mcp = FastMCP("crux", instructions="Crux AI operating system — knowledge, sessions, modes, and tool switching.")
+mcp = FastMCP("crux", instructions=(
+    "Crux AI operating system — knowledge, sessions, modes, and tool switching.\n\n"
+    "IMPORTANT: After every significant action (file edit, decision, task completion), "
+    "call update_session() with working_on, add_decision, or add_file as appropriate. "
+    "Session state must be continuously maintained so context can be restored at any time "
+    "without advance notice. This is NOT optional.\n\n"
+    "When switching tools, call switch_tool_to(tool_id). It auto-writes handoff from "
+    "accumulated session state and generates the target tool's MCP config.\n\n"
+    "On session start, call restore_context() to load previous session state."
+))
 
 
 def _home() -> str:

--- a/scripts/lib/crux_session.py
+++ b/scripts/lib/crux_session.py
@@ -122,6 +122,59 @@ def update_session(
     return state
 
 
+MAX_HANDOFF_ITEMS = 50
+
+
+def auto_handoff(project_crux_dir: str) -> str:
+    """Generate and write handoff content from accumulated session state.
+
+    Reads the current session state and produces a structured handoff
+    document. Writes it to the handoff file automatically. Returns the
+    handoff content string.
+    """
+    state = load_session(project_crux_dir)
+    lines: list[str] = ["# Session Handoff (auto-generated)", ""]
+
+    if state.active_mode:
+        lines.append(f"**Mode:** {state.active_mode}")
+    if state.active_tool:
+        lines.append(f"**Tool:** {state.active_tool}")
+    if state.working_on:
+        lines.append(f"**Working on:** {state.working_on}")
+    lines.append("")
+
+    if state.key_decisions:
+        lines.append("## Key Decisions")
+        for d in state.key_decisions[:MAX_HANDOFF_ITEMS]:
+            lines.append(f"- {d}")
+        if len(state.key_decisions) > MAX_HANDOFF_ITEMS:
+            lines.append(f"- ... and {len(state.key_decisions) - MAX_HANDOFF_ITEMS} more")
+        lines.append("")
+
+    if state.files_touched:
+        lines.append("## Files Touched")
+        for f in state.files_touched[:MAX_HANDOFF_ITEMS]:
+            lines.append(f"- {f}")
+        if len(state.files_touched) > MAX_HANDOFF_ITEMS:
+            lines.append(f"- ... and {len(state.files_touched) - MAX_HANDOFF_ITEMS} more")
+        lines.append("")
+
+    if state.pending:
+        lines.append("## Pending Tasks")
+        for p in state.pending:
+            lines.append(f"- {p}")
+        lines.append("")
+
+    if state.context_summary:
+        lines.append("## Context")
+        lines.append(state.context_summary)
+        lines.append("")
+
+    content = "\n".join(lines)
+    write_handoff(content, project_crux_dir)
+    return content
+
+
 def write_handoff(content: str, project_crux_dir: str) -> None:
     """Write handoff context for the next mode or tool."""
     path = _handoff_path(project_crux_dir)

--- a/scripts/lib/crux_tool_recipes.py
+++ b/scripts/lib/crux_tool_recipes.py
@@ -1,0 +1,165 @@
+"""Tool recipe engine — centralized knowledge of MCP config formats per tool.
+
+Each AI coding tool has its own config format for MCP servers. This module
+stores the "recipe" for each tool and generates correct configs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class ToolRecipe:
+    """Configuration recipe for an AI coding tool's MCP setup."""
+    tool_id: str
+    config_file: str        # Relative to project (or absolute for global)
+    root_key: str           # Top-level key: mcpServers, mcp, context_servers
+    type_value: str | None  # "stdio", "local", or None
+    command_format: str     # "string_args" or "merged_array"
+    env_key: str            # "env" or "environment"
+    project_scoped: bool    # True = per-project config, False = global only
+    launch_command: str     # How to start the tool
+
+
+RECIPES: dict[str, ToolRecipe] = {
+    "claude-code": ToolRecipe(
+        tool_id="claude-code",
+        config_file=".mcp.json",
+        root_key="mcpServers",
+        type_value="stdio",
+        command_format="string_args",
+        env_key="env",
+        project_scoped=True,
+        launch_command="claude",
+    ),
+    "cruxcli": ToolRecipe(
+        tool_id="cruxcli",
+        config_file=os.path.join(".cruxcli", "cruxcli.jsonc"),
+        root_key="mcp",
+        type_value="local",
+        command_format="merged_array",
+        env_key="environment",
+        project_scoped=True,
+        launch_command="cruxcli",
+    ),
+    "opencode": ToolRecipe(
+        tool_id="opencode",
+        config_file=os.path.join(".opencode", "opencode.jsonc"),
+        root_key="mcp",
+        type_value="local",
+        command_format="merged_array",
+        env_key="environment",
+        project_scoped=True,
+        launch_command="opencode",
+    ),
+    "cursor": ToolRecipe(
+        tool_id="cursor",
+        config_file=os.path.join(".cursor", "mcp.json"),
+        root_key="mcpServers",
+        type_value=None,
+        command_format="string_args",
+        env_key="env",
+        project_scoped=True,
+        launch_command="cursor .",
+    ),
+    "windsurf": ToolRecipe(
+        tool_id="windsurf",
+        config_file=os.path.join("~", ".codeium", "windsurf", "mcp_config.json"),
+        root_key="mcpServers",
+        type_value=None,
+        command_format="string_args",
+        env_key="env",
+        project_scoped=False,
+        launch_command="windsurf .",
+    ),
+    "zed": ToolRecipe(
+        tool_id="zed",
+        config_file=os.path.join("~", ".config", "zed", "settings.json"),
+        root_key="context_servers",
+        type_value=None,
+        command_format="string_args",
+        env_key="env",
+        project_scoped=False,
+        launch_command="zed .",
+    ),
+}
+
+
+def get_recipe(tool_id: str) -> ToolRecipe | None:
+    """Get the recipe for a tool, or None if unknown."""
+    return RECIPES.get(tool_id)
+
+
+def _resolve_config_path(recipe: ToolRecipe, project_dir: str) -> str:
+    """Resolve the config file path for a recipe."""
+    if recipe.project_scoped:
+        return os.path.join(project_dir, recipe.config_file)
+    return os.path.expanduser(recipe.config_file)
+
+
+def _build_server_entry(
+    recipe: ToolRecipe,
+    crux_python: str,
+    crux_repo: str,
+    project_dir: str,
+) -> dict:
+    """Build the MCP server entry dict for a recipe."""
+    entry: dict = {}
+
+    if recipe.type_value is not None:
+        entry["type"] = recipe.type_value
+
+    if recipe.command_format == "merged_array":
+        entry["command"] = [crux_python, "-m", "scripts.lib.crux_mcp_server"]
+    else:
+        entry["command"] = crux_python
+        entry["args"] = ["-m", "scripts.lib.crux_mcp_server"]
+
+    entry[recipe.env_key] = {
+        "CRUX_PROJECT": project_dir,
+        "CRUX_HOME": os.environ.get("HOME", ""),
+        "PYTHONPATH": crux_repo,
+    }
+
+    return entry
+
+
+def generate_mcp_config(
+    tool_id: str,
+    project_dir: str,
+    crux_repo: str,
+    crux_python: str,
+) -> bool:
+    """Generate the MCP config for a tool. Returns True on success, False if unknown tool."""
+    recipe = get_recipe(tool_id)
+    if recipe is None:
+        return False
+
+    config_path = _resolve_config_path(recipe, project_dir)
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+
+    # Read existing config to merge
+    existing: dict = {}
+    if os.path.isfile(config_path):
+        try:
+            with open(config_path) as f:
+                existing = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            existing = {}
+
+    # Build the crux server entry
+    server_entry = _build_server_entry(recipe, crux_python, crux_repo, project_dir)
+
+    # Merge into existing config
+    if recipe.root_key not in existing:
+        existing[recipe.root_key] = {}
+    existing[recipe.root_key]["crux"] = server_entry
+
+    with open(config_path, "w") as f:
+        json.dump(existing, f, indent=2)
+        f.write("\n")
+
+    return True

--- a/tests/test_auto_handoff.py
+++ b/tests/test_auto_handoff.py
@@ -1,0 +1,101 @@
+"""Tests for auto_handoff — generate handoff from accumulated session state."""
+
+import os
+
+import pytest
+
+from scripts.lib.crux_session import (
+    SessionState, save_session, auto_handoff, read_handoff,
+)
+from scripts.lib.crux_init import init_project
+
+
+@pytest.fixture
+def env(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    project = home / "project"
+    project.mkdir()
+    init_project(project_dir=str(project))
+    crux_dir = str(project / ".crux")
+    return {"project": str(project), "crux_dir": crux_dir}
+
+
+class TestAutoHandoff:
+    def test_returns_string(self, env):
+        state = SessionState(active_mode="build-py", active_tool="claude-code")
+        save_session(state, env["crux_dir"])
+        result = auto_handoff(env["crux_dir"])
+        assert isinstance(result, str)
+
+    def test_contains_mode(self, env):
+        state = SessionState(active_mode="debug", active_tool="claude-code")
+        save_session(state, env["crux_dir"])
+        result = auto_handoff(env["crux_dir"])
+        assert "debug" in result
+
+    def test_contains_tool(self, env):
+        state = SessionState(active_mode="build-py", active_tool="cruxcli")
+        save_session(state, env["crux_dir"])
+        result = auto_handoff(env["crux_dir"])
+        assert "cruxcli" in result
+
+    def test_contains_working_on(self, env):
+        state = SessionState(working_on="Building OAuth2 flow")
+        save_session(state, env["crux_dir"])
+        result = auto_handoff(env["crux_dir"])
+        assert "Building OAuth2 flow" in result
+
+    def test_contains_decisions(self, env):
+        state = SessionState(key_decisions=["Use JWT tokens", "PostgreSQL for sessions"])
+        save_session(state, env["crux_dir"])
+        result = auto_handoff(env["crux_dir"])
+        assert "JWT tokens" in result
+        assert "PostgreSQL" in result
+
+    def test_contains_files(self, env):
+        state = SessionState(files_touched=["auth.py", "db.py"])
+        save_session(state, env["crux_dir"])
+        result = auto_handoff(env["crux_dir"])
+        assert "auth.py" in result
+        assert "db.py" in result
+
+    def test_contains_pending(self, env):
+        state = SessionState(pending=["Write tests", "Deploy to staging"])
+        save_session(state, env["crux_dir"])
+        result = auto_handoff(env["crux_dir"])
+        assert "Write tests" in result
+
+    def test_writes_handoff_file(self, env):
+        state = SessionState(
+            active_mode="build-py",
+            active_tool="claude-code",
+            working_on="Auth refactor",
+        )
+        save_session(state, env["crux_dir"])
+        auto_handoff(env["crux_dir"])
+        content = read_handoff(env["crux_dir"])
+        assert content is not None
+        assert "Auth refactor" in content
+
+    def test_empty_state(self, env):
+        state = SessionState()
+        save_session(state, env["crux_dir"])
+        result = auto_handoff(env["crux_dir"])
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_no_session_file(self, env):
+        # Don't save any session
+        result = auto_handoff(env["crux_dir"])
+        assert isinstance(result, str)
+
+    def test_truncates_large_state(self, env):
+        state = SessionState(
+            key_decisions=[f"Decision {i}" for i in range(200)],
+            files_touched=[f"file_{i}.py" for i in range(200)],
+        )
+        save_session(state, env["crux_dir"])
+        result = auto_handoff(env["crux_dir"])
+        # Should still be reasonable length, not 200 of each
+        assert len(result) < 10000

--- a/tests/test_tool_recipes.py
+++ b/tests/test_tool_recipes.py
@@ -1,0 +1,146 @@
+"""Tests for crux_tool_recipes — tool recipe engine for MCP config generation."""
+
+import json
+import os
+
+import pytest
+
+from scripts.lib.crux_tool_recipes import (
+    ToolRecipe, RECIPES, get_recipe, generate_mcp_config,
+)
+
+
+class TestToolRecipe:
+    def test_all_six_tools_have_recipes(self):
+        expected = {"claude-code", "cruxcli", "opencode", "cursor", "windsurf", "zed"}
+        assert set(RECIPES.keys()) == expected
+
+    def test_recipe_fields(self):
+        r = RECIPES["claude-code"]
+        assert isinstance(r, ToolRecipe)
+        assert r.tool_id == "claude-code"
+        assert r.config_file
+        assert r.root_key
+        assert r.env_key
+
+    def test_get_recipe_valid(self):
+        r = get_recipe("claude-code")
+        assert r.tool_id == "claude-code"
+
+    def test_get_recipe_invalid(self):
+        assert get_recipe("nonexistent") is None
+
+
+class TestGenerateMcpConfig:
+    @pytest.fixture
+    def project(self, tmp_path):
+        home = tmp_path / "home"
+        home.mkdir()
+        p = home / "project"
+        p.mkdir()
+        return str(p)
+
+    def test_claude_code_format(self, project, tmp_path):
+        generate_mcp_config("claude-code", project, "/repo", "/repo/.venv/bin/python")
+        path = os.path.join(project, ".mcp.json")
+        assert os.path.isfile(path)
+        with open(path) as f:
+            config = json.load(f)
+        assert "mcpServers" in config
+        assert "crux" in config["mcpServers"]
+        entry = config["mcpServers"]["crux"]
+        assert entry["type"] == "stdio"
+        assert isinstance(entry["command"], str)
+        assert isinstance(entry["args"], list)
+        assert entry["env"]["CRUX_PROJECT"] == project
+
+    def test_cruxcli_format(self, project, tmp_path):
+        generate_mcp_config("cruxcli", project, "/repo", "/repo/.venv/bin/python")
+        path = os.path.join(project, ".cruxcli", "cruxcli.jsonc")
+        assert os.path.isfile(path)
+        with open(path) as f:
+            content = f.read()
+        # Should be valid JSON (we write without comments)
+        config = json.loads(content)
+        assert "mcp" in config
+        assert "crux" in config["mcp"]
+        entry = config["mcp"]["crux"]
+        assert entry["type"] == "local"
+        assert isinstance(entry["command"], list)
+        assert "environment" in entry
+
+    def test_opencode_format(self, project, tmp_path):
+        generate_mcp_config("opencode", project, "/repo", "/repo/.venv/bin/python")
+        path = os.path.join(project, ".opencode", "opencode.jsonc")
+        assert os.path.isfile(path)
+
+    def test_cursor_format(self, project, tmp_path):
+        generate_mcp_config("cursor", project, "/repo", "/repo/.venv/bin/python")
+        path = os.path.join(project, ".cursor", "mcp.json")
+        assert os.path.isfile(path)
+        with open(path) as f:
+            config = json.load(f)
+        assert "mcpServers" in config
+        entry = config["mcpServers"]["crux"]
+        assert "type" not in entry  # Cursor has no type field
+
+    def test_windsurf_global(self, project, tmp_path, monkeypatch):
+        fake_home = str(tmp_path / "fakehome")
+        os.makedirs(fake_home)
+        monkeypatch.setenv("HOME", fake_home)
+        generate_mcp_config("windsurf", project, "/repo", "/repo/.venv/bin/python")
+        path = os.path.join(fake_home, ".codeium", "windsurf", "mcp_config.json")
+        assert os.path.isfile(path)
+        with open(path) as f:
+            config = json.load(f)
+        assert "mcpServers" in config
+
+    def test_zed_global(self, project, tmp_path, monkeypatch):
+        fake_home = str(tmp_path / "fakehome")
+        os.makedirs(fake_home)
+        monkeypatch.setenv("HOME", fake_home)
+        generate_mcp_config("zed", project, "/repo", "/repo/.venv/bin/python")
+        path = os.path.join(fake_home, ".config", "zed", "settings.json")
+        assert os.path.isfile(path)
+        with open(path) as f:
+            config = json.load(f)
+        assert "context_servers" in config
+
+    def test_unknown_tool_returns_false(self, project):
+        result = generate_mcp_config("nonexistent", project, "/repo", "/repo/.venv/bin/python")
+        assert result is False
+
+    def test_merges_existing_config(self, project, tmp_path):
+        # Write an existing config with another server
+        mcp_path = os.path.join(project, ".mcp.json")
+        existing = {"mcpServers": {"other": {"command": "other-server"}}}
+        with open(mcp_path, "w") as f:
+            json.dump(existing, f)
+        generate_mcp_config("claude-code", project, "/repo", "/repo/.venv/bin/python")
+        with open(mcp_path) as f:
+            config = json.load(f)
+        assert "other" in config["mcpServers"]
+        assert "crux" in config["mcpServers"]
+
+    def test_corrupt_existing_config(self, project):
+        mcp_path = os.path.join(project, ".mcp.json")
+        with open(mcp_path, "w") as f:
+            f.write("not valid json{{{")
+        generate_mcp_config("claude-code", project, "/repo", "/repo/.venv/bin/python")
+        with open(mcp_path) as f:
+            config = json.load(f)
+        assert "crux" in config["mcpServers"]
+
+    def test_zed_merges_existing_settings(self, project, tmp_path, monkeypatch):
+        fake_home = str(tmp_path / "fakehome")
+        zed_dir = os.path.join(fake_home, ".config", "zed")
+        os.makedirs(zed_dir)
+        existing = {"theme": "dark", "font_size": 14}
+        with open(os.path.join(zed_dir, "settings.json"), "w") as f:
+            json.dump(existing, f)
+        monkeypatch.setenv("HOME", fake_home)
+        generate_mcp_config("zed", project, "/repo", "/repo/.venv/bin/python")
+        with open(os.path.join(zed_dir, "settings.json")) as f:
+            config = json.load(f)
+        assert config["theme"] == "dark"
+        assert "context_servers" in config


### PR DESCRIPTION
## Summary
- Always-on session state: MCP instructions mandate continuous update_session()
- auto_handoff() generates handoff from accumulated state automatically
- Tool recipe engine: 6 tools (Claude Code, CruxCLI, OpenCode, Cursor, Windsurf, Zed)
- Enhanced switch_tool_to: auto-handoff → sync → recipe fallback → launch instructions
- Zero-prep switching between any AI coding tool

## Test plan
- [x] 25 new tests (11 auto_handoff + 14 tool recipes)
- [x] 100% coverage on new modules
- [x] Full suite: 1399 passing
- [x] Converged via CruxDev (2 clean passes all phases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)