### PR TITLE
Session activation: auto-detect uningest sessions

### DIFF
--- a/scripts/lib/crux_mcp_handlers.py
+++ b/scripts/lib/crux_mcp_handlers.py
@@ -706,21 +706,89 @@ def handle_log_interaction(
 # restore_context — rebuild full session context after restart
 # ---------------------------------------------------------------------------
 
+def _detect_session_adoption(project_dir: str, home: str) -> dict:
+    """Detect un-ingested Claude Code session .jsonl files.
+
+    Infrastructure enforcement: detects available sessions without
+    relying on hooks or LLM cooperation.
+    """
+    result: dict = {"available": False}
+    try:
+        claude_projects = os.path.join(home, ".claude", "projects")
+        if not os.path.isdir(claude_projects):
+            return result
+
+        # Claude Code uses project path with / replaced by -
+        project_hash = "-" + project_dir.replace("/", "-")
+        session_dir = os.path.join(claude_projects, project_hash)
+        if not os.path.isdir(session_dir):
+            return result
+
+        # Find .jsonl files
+        jsonl_files = [
+            os.path.join(session_dir, f)
+            for f in os.listdir(session_dir)
+            if f.endswith(".jsonl") and os.path.isfile(os.path.join(session_dir, f))
+        ]
+        if not jsonl_files:
+            return result
+
+        # Check if already ingested
+        crux_dir = os.path.join(project_dir, ".crux")
+        checkpoint_path = os.path.join(crux_dir, "ingest", "checkpoint.json")
+        ingested: set[str] = set()
+        if os.path.isfile(checkpoint_path):
+            try:
+                with open(checkpoint_path) as f:
+                    cp = json.load(f)
+                ingested = set(cp.get("ingested_files", []))
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        uningest = [f for f in jsonl_files if f not in ingested]
+        if not uningest:
+            return result
+
+        # Count lines across uningest files
+        total_lines = 0
+        for fp in uningest:
+            try:
+                with open(fp) as f:
+                    total_lines += sum(1 for _ in f)
+            except OSError:
+                pass
+
+        result = {
+            "available": True,
+            "session_count": len(uningest),
+            "total_lines": total_lines,
+            "message": (
+                f"Found {len(uningest)} session log(s) with {total_lines} entries "
+                f"that haven't been ingested into Crux. Would you like to adopt "
+                f"these sessions for portability? This captures decisions, files "
+                f"touched, and corrections from previous sessions."
+            ),
+        }
+    except Exception as e:
+        logger.debug("Session adoption detection failed: %s", e)
+
+    return result
+
+
 def handle_restore_context(project_dir: str, home: str) -> dict:
     """Rebuild full session context for injection after a restart.
 
-    Returns a formatted context string containing:
-    - Active mode and its prompt
-    - Working on description
-    - Key decisions
-    - Pending tasks
-    - Files touched
-    - Handoff context
-    - Context summary
+    Also activates session logging and detects un-ingested session files.
+    Returns a formatted context string plus session_adoption info.
     """
     project_paths = get_project_paths(project_dir)
     user_paths = get_user_paths(home)
-    state = load_session(str(project_paths.root))
+
+    # Activate session: update timestamp, ensure state exists
+    crux_dir = str(project_paths.root)
+    update_session(project_crux_dir=crux_dir)
+
+    state = load_session(crux_dir)
     handoff = _read_handoff(str(project_paths.root))
 
     parts: list[str] = []
@@ -777,7 +845,18 @@ def handle_restore_context(project_dir: str, home: str) -> dict:
     if handoff:
         parts.append(f"\n## Handoff Context\n{handoff}")
 
-    return {"context": "\n".join(parts)}
+    resp: dict = {"context": "\n".join(parts)}
+
+    # Detect un-ingested session files (infrastructure enforcement)
+    adoption = _detect_session_adoption(project_dir, home)
+    if adoption.get("available"):
+        resp["session_adoption"] = adoption
+        parts.append(f"\n## Session Adoption Available\n{adoption['message']}")
+        resp["context"] = "\n".join(parts)
+    else:
+        resp["session_adoption"] = adoption
+
+    return resp
 
 
 def handle_verify_health(project_dir: str, home: str) -> dict:

--- a/scripts/lib/crux_mcp_server.py
+++ b/scripts/lib/crux_mcp_server.py
@@ -62,7 +62,10 @@ mcp = FastMCP("crux", instructions=(
     "without advance notice. This is NOT optional.\n\n"
     "When switching tools, call switch_tool_to(tool_id). It auto-writes handoff from "
     "accumulated session state and generates the target tool's MCP config.\n\n"
-    "On session start, call restore_context() to load previous session state."
+    "On session start, call restore_context() to load previous session state. "
+    "If the response includes session_adoption.available=true, inform the user "
+    "that previous session logs were detected and ask if they'd like to adopt "
+    "them into Crux for portability."
 ))
 
 

--- a/tests/test_session_activation.py
+++ b/tests/test_session_activation.py
@@ -1,0 +1,116 @@
+"""Tests for session activation on restore_context — auto-detect uningest sessions."""
+
+import json
+import os
+
+import pytest
+
+from scripts.lib.crux_mcp_handlers import handle_restore_context
+from scripts.lib.crux_init import init_project, init_user
+from scripts.lib.crux_session import SessionState, save_session, load_session
+
+
+@pytest.fixture
+def env(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    project = home / "project"
+    project.mkdir()
+    init_user(home=str(home))
+    init_project(project_dir=str(project))
+
+    # Create mode file
+    modes_dir = home / ".crux" / "modes"
+    (modes_dir / "build-py.md").write_text("You are a Python specialist.")
+
+    crux_dir = str(project / ".crux")
+    state = SessionState(active_mode="build-py", active_tool="claude-code")
+    save_session(state, crux_dir)
+    return {"home": str(home), "project": str(project), "crux_dir": crux_dir}
+
+
+class TestRestoreContextActivatesSession:
+    def test_updates_session_timestamp(self, env):
+        old_state = load_session(env["crux_dir"])
+        old_ts = old_state.updated_at
+
+        handle_restore_context(env["project"], env["home"])
+
+        new_state = load_session(env["crux_dir"])
+        assert new_state.updated_at >= old_ts
+
+    def test_returns_context(self, env):
+        result = handle_restore_context(env["project"], env["home"])
+        assert "context" in result
+        assert "build-py" in result["context"]
+
+
+class TestSessionAdoptionDetection:
+    def test_no_adoption_when_no_jsonl(self, env):
+        result = handle_restore_context(env["project"], env["home"])
+        assert result.get("session_adoption") is None or result["session_adoption"]["available"] is False
+
+    def test_detects_uningest_session_files(self, env):
+        # Create fake Claude Code session .jsonl files
+        claude_projects = os.path.join(env["home"], ".claude", "projects")
+        project_hash = "-" + env["project"].replace("/", "-")
+        session_dir = os.path.join(claude_projects, project_hash)
+        os.makedirs(session_dir, exist_ok=True)
+
+        # Write a session file with some content
+        session_file = os.path.join(session_dir, "abc123.jsonl")
+        entries = [
+            {"type": "human", "message": {"content": "build the auth module"}},
+            {"type": "assistant", "message": {"content": "I'll create auth.py"}},
+        ]
+        with open(session_file, "w") as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+
+        result = handle_restore_context(env["project"], env["home"])
+        adoption = result.get("session_adoption", {})
+        assert adoption.get("available") is True
+        assert adoption.get("session_count", 0) >= 1
+        assert adoption.get("total_lines", 0) >= 2
+
+    def test_no_adoption_when_already_ingested(self, env):
+        # Create session file AND checkpoint
+        claude_projects = os.path.join(env["home"], ".claude", "projects")
+        project_hash = "-" + env["project"].replace("/", "-")
+        session_dir = os.path.join(claude_projects, project_hash)
+        os.makedirs(session_dir, exist_ok=True)
+
+        session_file = os.path.join(session_dir, "abc123.jsonl")
+        with open(session_file, "w") as f:
+            f.write('{"type": "human"}\n')
+
+        # Create ingest checkpoint marking this file as processed
+        ingest_dir = os.path.join(env["crux_dir"], "ingest")
+        os.makedirs(ingest_dir, exist_ok=True)
+        checkpoint = {
+            "ingested_files": [session_file],
+            "status": "completed",
+        }
+        with open(os.path.join(ingest_dir, "checkpoint.json"), "w") as f:
+            json.dump(checkpoint, f)
+
+        result = handle_restore_context(env["project"], env["home"])
+        adoption = result.get("session_adoption", {})
+        assert adoption.get("available") is False
+
+    def test_adoption_message_is_clear(self, env):
+        # Create session file
+        claude_projects = os.path.join(env["home"], ".claude", "projects")
+        project_hash = "-" + env["project"].replace("/", "-")
+        session_dir = os.path.join(claude_projects, project_hash)
+        os.makedirs(session_dir, exist_ok=True)
+
+        session_file = os.path.join(session_dir, "def456.jsonl")
+        with open(session_file, "w") as f:
+            for _ in range(100):
+                f.write('{"type": "human", "message": {"content": "work"}}\n')
+
+        result = handle_restore_context(env["project"], env["home"])
+        adoption = result.get("session_adoption", {})
+        assert "message" in adoption
+        assert "session" in adoption["message"].lower()


### PR DESCRIPTION
## Summary
- restore_context() now activates session + detects un-ingested Claude Code .jsonl files
- Returns session_adoption offer when previous sessions found
- Infrastructure enforcement — no hooks or LLM cooperation needed
- MCP instructions updated to guide LLM on adoption offer

## Test plan
- [x] 6 new tests (detection, already-ingested, no files, clear message)
- [x] Full suite: 1413 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)