### PR TITLE
Fix session state quality + context restore

### DIFF
--- a/scripts/lib/crux_hooks.py
+++ b/scripts/lib/crux_hooks.py
@@ -546,23 +546,27 @@ _COMMIT_OUTPUT_RE = re.compile(r'\[[\w/.-]+\s+\w+\]\s+(.+)')
 def _extract_commit_message(tool_input: dict, tool_output: str) -> str | None:
     """Extract commit message from git commit commands.
 
-    Tries to parse from the command string first, falls back to output.
-    Returns the message or None if not a commit.
+    Prefers output (always clean) over command string (may have heredocs).
+    Returns the first line of the message or None if not a commit.
     """
     command = tool_input.get("command", "")
     if not isinstance(command, str) or "git commit" not in command:
         return None
 
-    # Try extracting from command: git commit -m "message"
-    match = _COMMIT_MSG_RE.search(command)
-    if match:
-        return match.group(1)[:256]
-
-    # Try extracting from output: [main abc123] message
+    # Prefer output: [main abc123] message — always clean
     if isinstance(tool_output, str):
         match = _COMMIT_OUTPUT_RE.search(tool_output)
         if match:
-            return match.group(1)[:256]
+            msg = match.group(1).strip()[:256]
+            if msg and not msg.startswith("$("):
+                return msg
+
+    # Fallback to command: git commit -m "message" (skip heredocs)
+    match = _COMMIT_MSG_RE.search(command)
+    if match:
+        msg = match.group(1).strip()[:256]
+        if msg and not msg.startswith("$("):
+            return msg
 
     return None
 

--- a/scripts/lib/crux_mcp_handlers.py
+++ b/scripts/lib/crux_mcp_handlers.py
@@ -823,10 +823,15 @@ def handle_restore_context(project_dir: str, home: str) -> dict:
     if state.context_summary:
         parts.append(f"\n## Context Summary\n{state.context_summary}")
 
-    # Key decisions
-    if state.key_decisions:
-        parts.append(f"\n## Key Decisions ({len(state.key_decisions)} total)")
-        for d in state.key_decisions:
+    # Key decisions (last 10, skip garbage)
+    clean_decisions = [
+        d for d in state.key_decisions
+        if d and not d.startswith("$(") and len(d) < 300
+    ]
+    if clean_decisions:
+        recent = clean_decisions[-10:]
+        parts.append(f"\n## Key Decisions ({len(clean_decisions)} total, showing last {len(recent)})")
+        for d in recent:
             parts.append(f"- {d}")
 
     # Pending tasks
@@ -835,10 +840,19 @@ def handle_restore_context(project_dir: str, home: str) -> dict:
         for task in state.pending:
             parts.append(f"- {task}")
 
-    # Files touched
+    # Files touched (last 20, deduplicated)
     if state.files_touched:
-        parts.append(f"\n## Files Touched ({len(state.files_touched)} files)")
+        # Deduplicate preserving order, take last 20
+        seen: set[str] = set()
+        unique: list[str] = []
         for f in state.files_touched:
+            basename = os.path.basename(f)
+            if basename not in seen:
+                seen.add(basename)
+                unique.append(f)
+        recent_files = unique[-20:]
+        parts.append(f"\n## Files Touched ({len(unique)} unique, showing last {len(recent_files)})")
+        for f in recent_files:
             parts.append(f"- {f}")
 
     # Handoff

--- a/scripts/lib/crux_session.py
+++ b/scripts/lib/crux_session.py
@@ -143,12 +143,17 @@ def auto_handoff(project_crux_dir: str) -> str:
         lines.append(f"**Working on:** {state.working_on}")
     lines.append("")
 
-    if state.key_decisions:
+    # Filter garbage decisions (heredoc captures, too-long entries)
+    clean_decisions = [
+        d for d in state.key_decisions
+        if d and not d.startswith("$(") and len(d) < 300
+    ]
+    if clean_decisions:
         lines.append("## Key Decisions")
-        for d in state.key_decisions[:MAX_HANDOFF_ITEMS]:
+        for d in clean_decisions[-MAX_HANDOFF_ITEMS:]:
             lines.append(f"- {d}")
-        if len(state.key_decisions) > MAX_HANDOFF_ITEMS:
-            lines.append(f"- ... and {len(state.key_decisions) - MAX_HANDOFF_ITEMS} more")
+        if len(clean_decisions) > MAX_HANDOFF_ITEMS:
+            lines.append(f"- ... and {len(clean_decisions) - MAX_HANDOFF_ITEMS} more")
         lines.append("")
 
     if state.files_touched:


### PR DESCRIPTION
## Summary
- Fix garbage decision capture from heredoc git commits (prefer output, skip $( prefix)
- restore_context returns concise context (last 10 decisions, last 20 files, filtered)
- auto_handoff applies same filtering
- Cleaned existing state.json (25→18 decisions, 244→50 files)

## Test plan
- [x] 1413 tests passing
- [x] Existing auto-capture and handoff tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)