### PR TITLE
Per-project MCP isolation: cache startup cwd

### DIFF
--- a/scripts/lib/crux_mcp_server.py
+++ b/scripts/lib/crux_mcp_server.py
@@ -69,12 +69,18 @@ mcp = FastMCP("crux", instructions=(
 ))
 
 
+# Cache cwd at import time — MCP server is spawned per-project by the tool,
+# so cwd at startup IS the project directory. os.getcwd() can drift if
+# subprocesses change directory.
+_STARTUP_CWD = os.getcwd()
+
+
 def _home() -> str:
     return os.environ.get("CRUX_HOME", os.environ.get("HOME", ""))
 
 
 def _project() -> str:
-    return os.environ.get("CRUX_PROJECT", os.getcwd())
+    return os.environ.get("CRUX_PROJECT", _STARTUP_CWD)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Cache os.getcwd() at MCP server import time for reliable project detection
- Each CruxCLI instance spawns its own MCP server with cwd=project dir
- No more CRUX_PROJECT in global config — server uses spawning tool's cwd

## Test plan
- [x] 1413 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)